### PR TITLE
Fix to make make package.json parsable

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "epub-gen": "0.0.13",
     "stream-counter": "^1.0.0",
-    "youtube-dl": "^1.10.5",
+    "youtube-dl": "^1.10.5"
   }
 }


### PR DESCRIPTION
The comma in line 14 made the file unparsable. This small change fixes it.